### PR TITLE
fixing warnings in stadium.hpp

### DIFF
--- a/include/stadium.hpp
+++ b/include/stadium.hpp
@@ -127,8 +127,8 @@ struct Stadium
 			to_target.y,
 			r.velocity.x * dt,
 			r.velocity.y * dt,
-			cos(r.angle),
-			sin(r.angle),
+			float(cos(r.angle)),
+			float(sin(r.angle)),
 			r.angular_velocity * dt
 		};
 		// The actual update


### PR DESCRIPTION
To fix the narrowing conversion warnings, we can explicitly cast the result of cos and sin to float